### PR TITLE
I18n support/IP verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,41 @@ class User < ActiveRecord::Base
 end
 ```
 
+DomainValidator can also check that the domain points to the same IP
+as a given domain. This is useful if you want users to set up their
+own CNAME for a given domain.
+
+```ruby
+class User < ActiveRecord::Base
+  attr_accessible :domain
+  validates :domain, :domain => {:verify_dns => true, :same_ip_as => "domains.myservice.com"}
+
+  # Also supports different messages for missing or incorrect DNS records
+  # validates :domain, :domain => {
+  #   :verify_dns => {
+  #     :same_ip_as => "domains.myservice.com",
+  #     :missing_dns_record => "DNS record not found",
+  #     :incorrect_dns_record => "Ensure domain is a CNAME for domains.myservice.com"
+  #   }
+  # }
+end
+```
+
+The `:same_ip_as` option also supports taking a lambda in case you
+need to read the value from a lazily initialized resource.
+
+```ruby
+class User < ActiveRecord::Base
+  attr_accessible :domain
+
+  validates :domain, :domain => {
+    :verify_dns => {
+      :same_ip_as => lambda { SomeLazy.config.domain }
+    }
+  }
+end
+```
+
 ## Examples
 
 ```ruby
@@ -64,7 +99,8 @@ The default error messages can be overridden via translations:
             attributes:
               domain:
                 invalid_domain: "Not a valid domain."
-                invalid_dns_record: "DNS check failed."
+                missing_dns_record: "DNS record not found."
+                invalid_dns_record: "DNS record is not setup correctly."
 
 See
 [Rails documentation](http://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-generate_message)

--- a/README.md
+++ b/README.md
@@ -53,12 +53,29 @@ user.domain = 'invalid*characters.com'
 user.valid? # => false
 ```
 
+## Translations
+
+The default error messages can be overridden via translations:
+
+    activerecord:
+      errors:
+        models:
+          user:
+            attributes:
+              domain:
+                invalid_domain: "Not a valid domain."
+                invalid_dns_record: "DNS check failed."
+
+See
+[Rails documentation](http://api.rubyonrails.org/classes/ActiveModel/Errors.html#method-i-generate_message)
+for a full list of possible translation scopes.
+
 ## Compatibility
 
 DomainValidator is tested against:
 
 MRI 1.9.3, 2.0, 2.1.1, 2.1.2
-JRuby 1.9  
+JRuby 1.9
 Rubinus 2.1.1
 
 ## Contributing

--- a/lib/domain_validator/dns_check.rb
+++ b/lib/domain_validator/dns_check.rb
@@ -3,13 +3,19 @@ require "resolv"
 module DomainValidator
   class DnsCheck
 
-    def self.has_record?(domain)
-      begin
-        Resolv::DNS.new.getaddress domain
-        return true
-      rescue Resolv::ResolvError => e
-        return false
+    def self.detect_issues(domain, options = {})
+      address = Resolv::DNS.new.getaddress(domain)
+
+      if options[:same_ip_as]
+        other_domain = options[:same_ip_as]
+        other_domain = other_domain.call if other_domain.respond_to?(:call)
+        other_address = Resolv::DNS.new.getaddress(other_domain)
+        return :incorrect_dns_record if other_address != address
       end
+
+      return nil
+    rescue Resolv::ResolvError => e
+      return :missing_dns_record
     end
 
   end

--- a/lib/domain_validator/validator.rb
+++ b/lib/domain_validator/validator.rb
@@ -33,7 +33,7 @@ module DomainValidator
     def verify_dns_message
       verify_dns = options[:verify_dns]
       if verify_dns.is_a? Hash
-        verify_dns[:message] || options[:message]
+        verify_dns[:message]
       end
     end
 

--- a/lib/domain_validator/validator.rb
+++ b/lib/domain_validator/validator.rb
@@ -3,8 +3,13 @@ require "active_model/validator"
 
 module DomainValidator
   class Validator < ActiveModel::EachValidator
-    
+
     RE_DOMAIN = %r(^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)+$)
+
+    DEFAULT_MESSAGES = {
+      :invalid_domain => "is invalid",
+      :invalid_dns_record => "does not have a DNS record"
+    }
 
     def validate_each(record, attr_name, value)
       validate_domain_format(record, attr_name, value)
@@ -13,13 +18,15 @@ module DomainValidator
     end
 
     def validate_domain_format(record, attr_name, value)
-      valid_domain = is_valid_domain?(value)
-      record.errors.add(attr_name, options[:message] || "is invalid") unless valid_domain
+      unless is_valid_domain?(value)
+        record.errors.add(attr_name, :invalid_domain, message: invalid_domain_message)
+      end
     end
 
     def validate_domain_dns(record, attr_name, value)
-      valid_domain = has_dns_record?(value)
-      record.errors.add(attr_name, verify_dns_message || "does not have a DNS record") unless valid_domain
+      unless has_dns_record?(value)
+        record.errors.add(attr_name, :invalid_dns_record, message: invalid_dns_record_message)
+      end
     end
 
     def is_valid_domain?(domain)
@@ -28,6 +35,14 @@ module DomainValidator
 
     def has_dns_record?(domain)
       options[:verify_dns] ? DnsCheck.has_record?(domain) : true
+    end
+
+    def invalid_domain_message
+      options[:message] || DEFAULT_MESSAGES[:invalid_domain]
+    end
+
+    def invalid_dns_record_message
+      verify_dns_message || DEFAULT_MESSAGES[:invalid_dns_record]
     end
 
     def verify_dns_message

--- a/lib/domain_validator/validator.rb
+++ b/lib/domain_validator/validator.rb
@@ -8,7 +8,7 @@ module DomainValidator
 
     DEFAULT_MESSAGES = {
       :invalid_domain => "is invalid",
-      :invalid_dns_record => "does not have a DNS record"
+      :invalid_dns_record => "does not have a valid DNS record"
     }
 
     def validate_each(record, attr_name, value)
@@ -24,31 +24,31 @@ module DomainValidator
     end
 
     def validate_domain_dns(record, attr_name, value)
-      unless has_dns_record?(value)
-        record.errors.add(attr_name, :invalid_dns_record, message: invalid_dns_record_message)
-      end
+      issue = detect_dns_issues(value)
+      record.errors.add(attr_name, issue, message: dns_message(issue)) if issue
     end
 
     def is_valid_domain?(domain)
       domain =~ RE_DOMAIN
     end
 
-    def has_dns_record?(domain)
-      options[:verify_dns] ? DnsCheck.has_record?(domain) : true
+    def detect_dns_issues(domain)
+      dns_options = options[:verify_dns].is_a?(Hash) ? options[:verify_dns] : {}
+      options[:verify_dns] ? DnsCheck.detect_issues(domain, dns_options) : nil
     end
 
     def invalid_domain_message
       options[:message] || DEFAULT_MESSAGES[:invalid_domain]
     end
 
-    def invalid_dns_record_message
-      verify_dns_message || DEFAULT_MESSAGES[:invalid_dns_record]
+    def dns_message(issue)
+      custom_dns_message(issue) || DEFAULT_MESSAGES[:invalid_dns_record]
     end
 
-    def verify_dns_message
+    def custom_dns_message(issue)
       verify_dns = options[:verify_dns]
       if verify_dns.is_a? Hash
-        verify_dns[:message]
+        verify_dns[issue] || verify_dns[:message]
       end
     end
 

--- a/spec/dns_check_spec.rb
+++ b/spec/dns_check_spec.rb
@@ -5,18 +5,37 @@ NOT_A_REAL_DOMAIN = "zjnajkndsjkangunausgnasngiuansiugnaiusngansjkgnaskjnaksjdn.
 
 module DomainValidator
   describe DnsCheck do
-    describe '#has_record?' do
+    describe '#detect_issues' do
 
       context "given a domain without a DNS record" do
-        it "should return false" do
-          expect( DnsCheck.has_record?(NOT_A_REAL_DOMAIN) ).to eq false
+        it "should return :missing_dns_record" do
+          expect( DnsCheck.detect_issues(NOT_A_REAL_DOMAIN) ).to eq(:missing_dns_record)
+        end
+      end
+
+      context "given a domain with a DNS record not matching reference domain" do
+        it "should return :incorrect_dns_record" do
+          result = DnsCheck.detect_issues("example.com", :same_ip_as => 'rubygems.org')
+          expect(result).to eq(:incorrect_dns_record)
+        end
+      end
+
+      context "given a domain with a DNS record matching reference domain" do
+        it "should return nil" do
+          result = DnsCheck.detect_issues("example.com", :same_ip_as => 'www.example.com')
+          expect(result).to eq(nil)
         end
       end
 
       context "given a domain with a DNS record" do
-        it "should return true" do
-          expect( DnsCheck.has_record?("example.com") ).to eq true
+        it "should return nil" do
+          expect( DnsCheck.detect_issues("example.com") ).to eq(nil)
         end
+      end
+
+      it "supports callable as :same_ip_as option" do
+        result = DnsCheck.detect_issues("example.com", :same_ip_as => -> { 'www.example.com' })
+        expect(result).to eq(nil)
       end
 
     end

--- a/spec/domain_validator_spec.rb
+++ b/spec/domain_validator_spec.rb
@@ -60,10 +60,17 @@ describe DomainValidator do
   describe "error messages" do
     context "when the :message option is not defined" do
       subject { User.new :domain => "notadomain" }
-      before { subject.valid? }
 
       it "should add the default message" do
+        subject.valid?
         expect(subject.errors[:domain]).to include "is invalid"
+      end
+
+      it "should prefer localized message" do
+        with_error_translation(subject, :invalid_domain, "not right") do
+          subject.valid?
+          expect(subject.errors[:domain]).to include "not right"
+        end
       end
     end
 
@@ -87,10 +94,17 @@ describe DomainValidator do
 
     context "when :verify_dns does not have a :message option" do
       subject { UserVerifyDNS.new :domain => "a.com" }
-      before { subject.valid? }
 
       it "should add the default message" do
+        subject.valid?
         expect(subject.errors[:domain]).to include "does not have a DNS record"
+      end
+
+      it "should prefer localized message" do
+        with_error_translation(subject, :invalid_dns_record, "dns not right") do
+          subject.valid?
+          expect(subject.errors[:domain]).to include "dns not right"
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,5 +19,7 @@ end
 
 RSpec.configure do |c|
   require 'support/domain_helpers'
+  require 'support/translations_helpers'
   c.extend DomainHelpers
+  c.include TranslationsHelpers
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -33,3 +33,30 @@ end
 class UserVerifyDNSMessage < Model
   validates :domain, :domain => {:verify_dns => {:message => "failed DNS check"}}
 end
+
+class UserVerifyExampleDotCom < Model
+  validates :domain, :domain => {
+    :verify_dns => {
+      :same_ip_as => "example.com"
+    }
+  }
+end
+
+class UserVerifyExampleDotComWithMessage < Model
+  validates :domain, :domain => {
+    :verify_dns => {
+      :same_ip_as => "example.com",
+      :message => "failed DNS check"
+    }
+  }
+end
+
+class UserVerifyExampleDotComWithSpecificMessages < Model
+  validates :domain, :domain => {
+    :verify_dns => {
+      :same_ip_as => "example.com",
+      :incorrect_dns_record => "wrong ip",
+      :missing_dns_record => "missing record"
+    }
+  }
+end

--- a/spec/support/translations_helpers.rb
+++ b/spec/support/translations_helpers.rb
@@ -1,0 +1,32 @@
+module TranslationsHelpers
+  def with_error_translation(subject, type, message, &block)
+    translations = {
+      :activemodel => {
+        :errors => {
+          :models => {
+            subject.model_name.singular => {
+              :attributes => {
+                :domain => {
+                  type => message
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    with_translations(translations, &block)
+  end
+
+  def with_translations(translations)
+    original_backend = I18n.backend
+
+    I18n.backend = I18n::Backend::KeyValue.new(Hash.new, true)
+    I18n.backend.store_translations(I18n.locale, translations)
+
+    yield
+  ensure
+    I18n.backend = original_backend
+  end
+end


### PR DESCRIPTION
This PR contains two new features.

I'd be happy if you could review my changes. I can split it into two separate PRs. But since the commits build on one another, I wanted to get your feedback first.

**Add support for localized error messages**
- Pass symbol to `errors.add` method, to trigger translation lookup
- Provide custom messages and default fallback via `:message` option
- Test that translations are actually used as expected

**Add a `:same_ip_as` option to `:verify_dns`**

Given a SaaS website which lets users setup their own CNAME to access
some resource, we want to ensure that the DNS record is not only
present but points to the correct domain. To do this, we can check
that the domain resolves to the same IP as the target domain for the
CNAME.
