### PR TITLE
Restrict Travis runs to Ruby 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+# Use container based travis infrastructure
+sudo: false
+
 language: ruby
 rvm:
-  - 1.9.3
-  - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2.1.1
-  - 2.0.0
-  - 2.1.1
-  - 2.1.2
+  - rbx
+  - 2.2.2
+
+matrix:
+  allow_failures:
+    - rvm: rbx


### PR DESCRIPTION
Rails 5 gems require Ruby >= 2.2.2. If we want to keep supporting
older versions, we'll need to build an Appraisal setup to restrict
Rails to 4 when running with Ruby < 2.2.2.
